### PR TITLE
feat: replace `serde_molecule` with `serde_json`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +184,16 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+dependencies = [
+ "num-traits",
+ "serde",
+]
 
 [[package]]
 name = "ckb-always-success-script"
@@ -820,6 +836,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,6 +878,15 @@ checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -987,6 +1047,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
@@ -1198,6 +1264,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "includedir"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,9 +1318,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "libloading"
@@ -1357,6 +1429,21 @@ dependencies = [
  "bytes",
  "cfg-if",
  "faster-hex",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1491,6 +1578,12 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1775,6 +1868,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1863,7 +1984,7 @@ version = "9.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7a2b3c2bc9693bcb40870c4e9b5bf0d79f9cb46273321bf855ec513e919082"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "digest",
  "hex",
  "miette",
@@ -1873,6 +1994,12 @@ dependencies = [
  "thiserror",
  "xxhash-rust",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1949,6 +2076,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
 name = "tokio"
 version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,6 +2168,7 @@ dependencies = [
  "ckb-std",
  "serde",
  "serde_json",
+ "serde_with",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "autocfg"
@@ -130,9 +130,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 dependencies = [
  "serde",
 ]
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
 dependencies = [
  "shlex",
 ]
@@ -501,8 +501,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "serde_molecule",
- "syn 2.0.89",
+ "serde_json",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -515,7 +515,7 @@ dependencies = [
  "hex",
  "log",
  "serde",
- "serde_molecule",
+ "serde_json",
 ]
 
 [[package]]
@@ -816,7 +816,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -839,7 +839,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -937,17 +937,17 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -958,9 +958,9 @@ checksum = "51e2ce894d53b295cf97b05685aa077950ff3e8541af83217fc720a6437169f8"
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
@@ -1044,7 +1044,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1183,12 +1183,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,15 +1246,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.165"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb4d3d38eab6c5239a362fa8bae48c03baf980a6e7079f063942d563ef3533e"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libloading"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets",
@@ -1331,7 +1325,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1345,11 +1339,10 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
@@ -1654,15 +1647,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.41"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1755,7 +1748,7 @@ checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1778,15 +1771,6 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_molecule"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f15166380b1d060472fd8eb7fe3cc58027cf32f7983832db3e2f97ac4ee71740"
-dependencies = [
  "serde",
 ]
 
@@ -1909,9 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.89"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1961,14 +1945,14 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1988,14 +1972,14 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2037,7 +2021,7 @@ dependencies = [
  "ckb-script-ipc-common",
  "ckb-std",
  "serde",
- "serde_molecule",
+ "serde_json",
 ]
 
 [[package]]
@@ -2139,7 +2123,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2150,7 +2134,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2278,7 +2262,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ case, version + method id + length only occupies 3 bytes.
       serialization/deserialization.
     - error code: Only appears in Response, range is 0 to 2^64.
     - payload: Defined by the service provider, developers can choose freely.
-      You can use `molecule` to define the data, or choose other methods.
+      You can use `json` to define the data, or choose other methods.
 
 In theory, VLQ can represent integers of any length, but considering practical
 implementation, we need to set a boundary for easier code processing. Currently,
@@ -171,7 +171,7 @@ pub struct Struct0 {
 
 Q: What serialize/deserialize format is used for message packing and unpacking?
 
-A: [serde_molecule](https://github.com/XuJiandong/serde_molecule)
+A: [serde_json](https://crates.io/crates/serde_json)
 
 Q: How can I view code expanded by `#[ckb_script_ipc::service]`?
 
@@ -185,24 +185,3 @@ Communication (IPC) rather than Remote Procedure Call (RPC). RPC encompasses
 additional features such as encryption, authentication, error propagation,
 retries and timeouts, scaling, and more. This crate focuses on a limited subset of
 these features, primarily those relevant to IPC.
-
-
-## Vector issue
-By default, `Vec` is serialized into a [molecule
-fixvec](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0008-serialization/0008-serialization.md#fixvec---fixed-vector).
-This works well for simple types like `Vec<u8>` or `Vec<[u8; 4]>`. However, it
-does not support complex element types such as `Vec<Vec<u8>>`. These should be
-serialized into a [molecule
-dynvec](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0008-serialization/0008-serialization.md#dynvec---dynamic-vector).
-In `serde_molecule`, this can be annotated using `#[serde(with = "dynvec_serde")]`.
-Since this crate does not provide a way to annotate method types, it is recommended to define a new type to avoid this issue:
-
-```rust,ignore
-use serde_molecule::dynvec_serde;
-
-#[derive(Serialize, Deserialize)]
-struct TwoDimVec {
-    #[serde(with = "dynvec_serde")]
-    pub inner: Vec<Vec<u8>>
-}
-```

--- a/contracts/unit-tests/Cargo.toml
+++ b/contracts/unit-tests/Cargo.toml
@@ -8,4 +8,4 @@ ckb-std = { version = "0.16", default-features = false, features = ["allocator",
 ckb-script-ipc-common = { path = "../../crates/ckb-script-ipc-common" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 ckb-script-ipc = { path = "../../crates/ckb-script-ipc" }
-serde_molecule = { version = "1.1.0", default-features = false, features = ["alloc"] }
+serde_json = { version = "1.0.133", default-features = false, features = ["alloc"] }

--- a/contracts/unit-tests/Cargo.toml
+++ b/contracts/unit-tests/Cargo.toml
@@ -9,3 +9,4 @@ ckb-script-ipc-common = { path = "../../crates/ckb-script-ipc-common" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 ckb-script-ipc = { path = "../../crates/ckb-script-ipc" }
 serde_json = { version = "1.0.133", default-features = false, features = ["alloc"] }
+serde_with = { version = "3.11.0", default-features = false, features = ["hex", "macros"] }

--- a/contracts/unit-tests/src/def.rs
+++ b/contracts/unit-tests/src/def.rs
@@ -2,6 +2,7 @@
 
 use alloc::{collections::btree_map::BTreeMap, string::String, vec::Vec};
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Default, Debug)]
 pub struct Struct0 {
@@ -10,12 +11,14 @@ pub struct Struct0 {
     pub f2: [u8; 3],
 }
 
+#[serde_as]
 #[derive(Serialize, Deserialize, Clone, PartialEq, Default, Debug)]
 pub struct Struct1 {
     pub f1: u8,
     pub f2: u16,
     pub f3: [u8; 3],
     pub f4: [[u8; 5]; 2],
+    #[serde_as(as = "serde_with::hex::Hex")]
     pub f5: Vec<u8>,
     pub f6: String,
     pub f7: Option<u32>,

--- a/contracts/unit-tests/src/def.rs
+++ b/contracts/unit-tests/src/def.rs
@@ -2,7 +2,6 @@
 
 use alloc::{collections::btree_map::BTreeMap, string::String, vec::Vec};
 use serde::{Deserialize, Serialize};
-use serde_molecule::{dynvec_serde, struct_serde};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Default, Debug)]
 pub struct Struct0 {
@@ -20,9 +19,7 @@ pub struct Struct1 {
     pub f5: Vec<u8>,
     pub f6: String,
     pub f7: Option<u32>,
-    #[serde(with = "dynvec_serde")]
     pub f8: Vec<Vec<u8>>,
-    #[serde(with = "struct_serde")]
     pub f9: Struct0,
 }
 

--- a/crates/ckb-script-ipc-common/Cargo.toml
+++ b/crates/ckb-script-ipc-common/Cargo.toml
@@ -14,7 +14,7 @@ description = "Common utilities for CKB Script IPC."
 [dependencies]
 ckb-std = { version = "0.16", default-features = false, features = ["allocator", "ckb-types", "dummy-atomic"]}
 serde = { version = "1.0.208", default-features = false, features = ["derive"] }
-serde_molecule = { version = "1.1.0", default-features = false, features = ["alloc"] }
+serde_json = { version = "1.0.133", default-features = false, features = ["alloc"] }
 hex = { version = "0.4", default-features = false, features = ["alloc"]}
 log = { version = "0.4", optional = true, default-features = false }
 enumn = "0.1.14"

--- a/crates/ckb-script-ipc-common/src/channel.rs
+++ b/crates/ckb-script-ipc-common/src/channel.rs
@@ -6,7 +6,7 @@ use crate::{
 use alloc::vec;
 use ckb_rust_std::io::{BufReader, BufWriter, Read, Write};
 use serde::{Deserialize, Serialize};
-use serde_molecule::{from_slice, to_vec};
+use serde_json::{from_slice, to_vec};
 
 /// The `Channel` struct facilitates communication between a client and a server.
 /// It handles the transmission of requests from the client to the server and the reception
@@ -139,7 +139,7 @@ impl<R: Read, W: Write> Channel<R, W> {
         }
     }
     pub fn send_request<Req: Serialize>(&mut self, req: Req) -> Result<(), IpcError> {
-        let serialized_req = to_vec(&req, false).map_err(|_| IpcError::SerializeError)?;
+        let serialized_req = to_vec(&req).map_err(|_| IpcError::SerializeError)?;
         let packet = RequestPacket::new(serialized_req);
         #[cfg(feature = "enable-logging")]
         log::info!("send request: {:?}", packet);
@@ -150,7 +150,7 @@ impl<R: Read, W: Write> Channel<R, W> {
         Ok(())
     }
     pub fn send_response<Resp: Serialize>(&mut self, resp: Resp) -> Result<(), IpcError> {
-        let serialized_resp = to_vec(&resp, false).map_err(|_| IpcError::SerializeError)?;
+        let serialized_resp = to_vec(&resp).map_err(|_| IpcError::SerializeError)?;
         let packet = ResponsePacket::new(0, serialized_resp);
         #[cfg(feature = "enable-logging")]
         log::info!("send response: {:?}", packet);
@@ -173,7 +173,7 @@ impl<R: Read, W: Write> Channel<R, W> {
         let packet = RequestPacket::read_from(&mut self.reader)?;
         #[cfg(feature = "enable-logging")]
         log::info!("receive request: {:?}", packet);
-        let req = from_slice(packet.payload(), false).map_err(|_| IpcError::DeserializeError)?;
+        let req = from_slice(packet.payload()).map_err(|_| IpcError::DeserializeError)?;
         Ok(req)
     }
     pub fn receive_response<Resp: for<'de> Deserialize<'de>>(&mut self) -> Result<Resp, IpcError> {
@@ -191,6 +191,6 @@ impl<R: Read, W: Write> Channel<R, W> {
                 return Err(IpcError::ProtocolError(e));
             }
         }
-        from_slice(packet.payload(), false).map_err(|_| IpcError::DeserializeError)
+        from_slice(packet.payload()).map_err(|_| IpcError::DeserializeError)
     }
 }

--- a/crates/ckb-script-ipc/Cargo.toml
+++ b/crates/ckb-script-ipc/Cargo.toml
@@ -21,4 +21,4 @@ proc-macro = true
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 ckb-script-ipc-common = { path = "../ckb-script-ipc-common" }
-serde_molecule = { version = "1.1.0", default-features = false, features = ["alloc"] }
+serde_json = { version = "1.0.133", default-features = false, features = ["alloc"] }

--- a/crates/ckb-script-ipc/tests/generate.rs
+++ b/crates/ckb-script-ipc/tests/generate.rs
@@ -28,8 +28,6 @@ extern crate alloc;
 use alloc::collections::BTreeMap;
 use alloc::collections::LinkedList;
 use ckb_script_ipc_common::pipe::Pipe;
-use serde_molecule::dynvec_serde;
-use serde_molecule::struct_serde;
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct Struct1 {
@@ -40,10 +38,8 @@ pub struct Struct1 {
     pub f5: Vec<u8>,
     pub f6: String,
     pub f7: Option<u32>,
-    #[serde(with = "dynvec_serde")]
     pub f8: Vec<Vec<u8>>,
     pub f9: LinkedList<[u8; 3]>,
-    #[serde(with = "struct_serde")]
     pub f11: BTreeMap<u32, String>,
 }
 


### PR DESCRIPTION
Performance Impact Analysis:

Binary Size Changes:
- unit-tests: 120KB → 178KB (+58KB)
- ckb_script_ipc_demo: 74KB → 117KB (+43KB)

Execution Cycles:
- unit_tests: 429K → 418K (-2.6%)
- ckb_script_ipc_demo: 235K → 258K (+9.8%)

Summary:
The changes resulted in a moderate increase in binary size (approximately +50KB per binary) while execution cycles remained relatively stable. 

